### PR TITLE
ogc-api-features - fixing links depending on the requested format

### DIFF
--- a/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/server/impl/CollectionsApiImpl.java
+++ b/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/server/impl/CollectionsApiImpl.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.MimeType;
+import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -167,6 +168,10 @@ public class CollectionsApiImpl implements CollectionsApiDelegate {
             Integer offset = extractOffset(request);
             int limit = dataQuery.getLimit() == null ? 10 : dataQuery.getLimit();
             Integer next = offset == null ? limit : offset + limit;
+            // f parameter preempts the "Accept" header
+            final String formatParam = request.getParameter("f");
+            builder.replaceQueryParam("f",
+                    StringUtils.hasText(formatParam) ? formatParam : requestedFormat.getShortName());
             UriComponents nextUri = builder.replaceQueryParam("offset", next.toString())
                     .replaceQueryParam("limit", limit).build();
             fc.getLinks().add(1, link(nextUri.toString(), "next", mime, "Next page"));

--- a/src/services/ogc-features/src/test/java/com/camptocamp/opendata/ogc/features/http/codec/MimeTypesTest.java
+++ b/src/services/ogc-features/src/test/java/com/camptocamp/opendata/ogc/features/http/codec/MimeTypesTest.java
@@ -1,0 +1,23 @@
+package com.camptocamp.opendata.ogc.features.http.codec;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MimeTypesTest {
+
+    public @Test void testFindByShortName() {
+        Optional<MimeTypes> ret = MimeTypes.findByShortName("geojson");
+
+        assertTrue(ret.isPresent() && ret.get().equals(MimeTypes.GeoJSON));
+    }
+
+    public @Test void testFindByHeader() {
+        Optional<MimeTypes> ret = MimeTypes.find("application/json");
+
+        assertTrue(ret.isPresent() && ret.get().equals(MimeTypes.JSON));
+    }
+
+}

--- a/src/services/ogc-features/src/test/java/com/camptocamp/opendata/ogc/features/server/impl/CollectionsApiImplTest.java
+++ b/src/services/ogc-features/src/test/java/com/camptocamp/opendata/ogc/features/server/impl/CollectionsApiImplTest.java
@@ -1,11 +1,67 @@
 package com.camptocamp.opendata.ogc.features.server.impl;
 
+import com.camptocamp.opendata.ogc.features.app.OgcFeaturesApp;
+import com.camptocamp.opendata.ogc.features.model.FeatureCollection;
+import com.camptocamp.opendata.ogc.features.model.Link;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.context.ActiveProfiles;
 
-import com.camptocamp.opendata.ogc.features.app.OgcFeaturesApp;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest(classes = OgcFeaturesApp.class)
 @ActiveProfiles("sample-data")
 public class CollectionsApiImplTest extends AbstractCollectionsApiImplIT {
+
+    @Test
+    public void testGetItemsLinks() {
+        MockHttpServletRequest mockedReq = (MockHttpServletRequest) req.getNativeRequest();
+        mockedReq.addParameter("f", "geojson");
+        mockedReq.addHeader("Accept", "application/geo+json");
+
+        ResponseEntity<FeatureCollection> response = collectionsApi.getFeatures("locations", //
+                10, //
+                null, //
+                null, //
+                null);
+
+        List<Link> links = response.getBody().getLinks();
+        assertTrue(links.get(1).getHref().contains("f=geojson"));
+    }
+
+    public @Test void testGetItemsLinksNoFParam() {
+        MockHttpServletRequest mockedReq = (MockHttpServletRequest) req.getNativeRequest();
+        mockedReq.removeParameter("f");
+        mockedReq.addHeader("Accept", "application/json");
+
+        ResponseEntity<FeatureCollection> response = collectionsApi.getFeatures("locations", //
+                10, //
+                null, //
+                null, //
+                null);
+
+        List<Link> links = response.getBody().getLinks();
+        assertTrue(links.get(1).getHref().contains("f=json"));
+    }
+
+    public @Test void testGetItemsLinksFParamAndDifferentHeaderParams() {
+        MockHttpServletRequest mockedReq = (MockHttpServletRequest) req.getNativeRequest();
+        mockedReq.addParameter("f", "ooxml");
+        mockedReq.addHeader("Accept", "application/json");
+
+        ResponseEntity<FeatureCollection> response = collectionsApi.getFeatures("locations", //
+                10, //
+                null, //
+                null, //
+                null);
+
+        List<Link> links = response.getBody().getLinks();
+        assertTrue(links.get(1).getHref().contains("f=ooxml"));
+    }
+
 }


### PR DESCRIPTION
When requesting the `/collections/<collection_name>/items`, the "next page" link being generated is making use of ooxml format by default:

```
[...]
{
  href: "https://host/ogcapi/collections/<collection_name>/items?f=ooxml&offset=10&limit=10",
  rel: "next",
  type: "application/geo+json",
  title: "Next page"
[...]
},
```
This PR suggests to use the "f" parameter if provided, or the mimetype detected from the Accept header if not used.
