### PR TITLE
links - using the right static method to generate links (fix #18)

### DIFF
--- a/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/server/impl/CollectionsApiImpl.java
+++ b/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/server/impl/CollectionsApiImpl.java
@@ -133,7 +133,7 @@ public class CollectionsApiImpl implements CollectionsApiDelegate {
         HttpServletRequest nativeRequest = (HttpServletRequest) request.getNativeRequest();
         String basePath = nativeRequest.getRequestURL().toString();
         collections.getCollections().forEach(c -> {
-            String colBase = UriComponentsBuilder.fromPath(basePath).pathSegment(c.getId()).build().toString();
+            String colBase = UriComponentsBuilder.fromUriString(basePath).pathSegment(c.getId()).build().toString();
             addLinks(c, colBase);
         });
         return collections;
@@ -146,7 +146,7 @@ public class CollectionsApiImpl implements CollectionsApiDelegate {
     }
 
     private Collection addLinks(Collection collection, String baseUrl) {
-        UriComponentsBuilder builder = UriComponentsBuilder.fromPath(baseUrl);
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(baseUrl);
         builder.pathSegment("items");
 
         MimeTypes defFormat = MimeTypes.GeoJSON;


### PR DESCRIPTION
Call UriComponentsBuilder's `fromUriString` instead of `fromPath` which sounds more relevant when using the base URL as argument.

This allows to avoid generating 'http:/localhost' links (with a missing slash after the scheme).

Tests: runtime tested, `mvn clean verify` still ok.